### PR TITLE
Add optional Plaid investment integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ A toy multi-agent financial planning assistant built with LangGraph.
 
 2. **Environment variables**
    - `OPENAI_API_KEY` – OpenAI key for language model responses (optional).
-   - `PLAID_CLIENT_ID` and `PLAID_SECRET` – credentials for Plaid API (optional, for `plaid_test.py`).
-   - `ACCESS_TOKEN` – Plaid access token for fetching transactions.
+   - `PLAID_CLIENT_ID` and `PLAID_SECRET` – credentials for Plaid API (optional, required for Plaid features).
+   - `ACCESS_TOKEN` – Plaid access token for fetching account data.
 
    You can create a `.env` file and export the keys:
    ```bash
@@ -31,3 +31,10 @@ python main.py
 ```
 
 This will run a few sample queries through the FinLife Navigator graph.
+
+### Plaid Integration
+
+If `PLAID_CLIENT_ID`, `PLAID_SECRET`, and `ACCESS_TOKEN` are provided, the
+`InvestmentAgent` will fetch your sandbox account balance via Plaid when a
+query explicitly confirms an investment action (e.g. "invest now"). The
+projected balance after allocation is included in the response.

--- a/agents/investment_agent.py
+++ b/agents/investment_agent.py
@@ -1,7 +1,13 @@
-"""Simple investment strategy generation."""
+"""Simple investment strategy generation.
+
+This agent optionally uses the Plaid API in sandbox mode to fetch the
+current account balance when the user confirms an investment action. It
+then projects the balance after the suggested allocation."""
 
 from typing import Dict, Any
+import os
 from .openai_utils import generate_response
+from .plaid_service import fetch_account_balance
 
 
 class InvestmentAgent:
@@ -10,6 +16,10 @@ class InvestmentAgent:
     def process(self, state: Dict[str, Any]) -> Dict[str, Any]:
         context = state.get("context", {}) or {}
         amount_str = context.get("amount")
+        execute_plaid = context.get("execute_plaid", False)
+
+        access_token = os.getenv("ACCESS_TOKEN") if execute_plaid else None
+        starting_balance = fetch_account_balance(access_token) if access_token else None
 
         try:
             amount = float(amount_str) if amount_str else None
@@ -24,6 +34,11 @@ class InvestmentAgent:
                 f"Invest ${stocks:.2f} in stocks, ${bonds:.2f} in bonds, and "
                 f"keep ${cash:.2f} in cash or equivalents."
             )
+
+            if execute_plaid and starting_balance is not None:
+                projected = starting_balance + amount
+                base += f" Your new balance could be around ${projected:.2f}."
+
             result = generate_response(
                 f"Provide a short investment suggestion based on: {base}"
             )
@@ -31,8 +46,12 @@ class InvestmentAgent:
             base = "Recommend 60% stocks, 30% bonds and 10% cash for a balanced portfolio."
             result = generate_response(base)
 
+        metadata = {"amount": amount}
+        if starting_balance is not None:
+            metadata["starting_balance"] = starting_balance
+
         return {
             "result": result,
             "confidence_score": 0.88,
-            "metadata": {"amount": amount},
+            "metadata": metadata,
         }

--- a/agents/plaid_service.py
+++ b/agents/plaid_service.py
@@ -1,0 +1,30 @@
+import os
+from typing import Optional
+from plaid.api import plaid_api
+from plaid import Configuration, ApiClient
+from plaid.model.accounts_balance_get_request import AccountsBalanceGetRequest
+
+
+def get_client() -> Optional[plaid_api.PlaidApi]:
+    client_id = os.getenv("PLAID_CLIENT_ID")
+    secret = os.getenv("PLAID_SECRET")
+    if not client_id or not secret:
+        return None
+    configuration = Configuration(host="https://sandbox.plaid.com", api_key={"clientId": client_id, "secret": secret})
+    api_client = ApiClient(configuration)
+    return plaid_api.PlaidApi(api_client)
+
+
+def fetch_account_balance(access_token: str) -> Optional[float]:
+    client = get_client()
+    if not client:
+        return None
+    try:
+        request = AccountsBalanceGetRequest(access_token=access_token)
+        response = client.accounts_balance_get(request)
+        accounts = response["accounts"]
+        if not accounts:
+            return None
+        return accounts[0]["balances"].get("available") or accounts[0]["balances"].get("current")
+    except Exception:
+        return None

--- a/agents/planner.py
+++ b/agents/planner.py
@@ -74,12 +74,18 @@ class PlannerAgent:
         if time_matches:
             context["timeframe"] = time_matches[0]
         
+
         # Determine if multiple agents might be needed
-        if len([qt for qt in self.query_patterns.keys() 
-                if any(re.search(p, user_input, re.IGNORECASE) 
+        if len([qt for qt in self.query_patterns.keys()
+                if any(re.search(p, user_input, re.IGNORECASE)
                       for p in self.query_patterns[qt])]) > 1:
             context["requires_multiple_agents"] = True
-        
+
+        # Check if user confirmed executing an investment action
+        confirm_keywords = ["invest now", "execute", "confirm", "do it", "deposit"]
+        if any(kw in user_input for kw in confirm_keywords):
+            context["execute_plaid"] = True
+
         return context
     
     def _needs_explanation(self, user_input: str) -> bool:


### PR DESCRIPTION
## Summary
- detect confirmation keywords in `PlannerAgent`
- include optional Plaid balance lookup in `InvestmentAgent`
- add helper `plaid_service.py`
- document Plaid integration in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python main.py` *(fails if dependencies or API keys missing)*

------
https://chatgpt.com/codex/tasks/task_e_68428b7399a8833292884dda556dd066